### PR TITLE
feature(accessibility): focus management

### DIFF
--- a/lib/components/HashLinkObserver.jsx
+++ b/lib/components/HashLinkObserver.jsx
@@ -33,14 +33,18 @@ var HashLinkObserver = function (_a) {
         var elementId = hash.slice(1);
         var element = document.getElementById(elementId);
         if (element) {
+            element.setAttribute('tabindex', '-1');
             element.scrollIntoView(scrollIntoViewOptions);
+            element.focus();
             return;
         }
         // If there is a hash ID but no element, re-check after each DOM mutation
         loadingObserver = new MutationObserver(function (_, observer) {
             var missingElement = document.getElementById(elementId);
             if (missingElement) {
+                missingElement.setAttribute('tabindex', '-1');
                 missingElement.scrollIntoView(scrollIntoViewOptions);
+                missingElement.focus();
                 observer_1.resetLoadingObserver(observer, observerTimeout);
             }
         });

--- a/src/components/HashLinkObserver.tsx
+++ b/src/components/HashLinkObserver.tsx
@@ -39,7 +39,9 @@ const HashLinkObserver: React.FC<Props> = ({isPageLoading, smoothScroll = true})
       const elementId = hash.slice(1);
       const element = document.getElementById(elementId);
       if (element) {
+        element.setAttribute('tabindex', '-1');
         element.scrollIntoView(scrollIntoViewOptions);
+        element.focus();
         return;
       }
 
@@ -47,7 +49,9 @@ const HashLinkObserver: React.FC<Props> = ({isPageLoading, smoothScroll = true})
       loadingObserver = new MutationObserver((_: MutationRecord[], observer: MutationObserver) => {
         const missingElement = document.getElementById(elementId);
         if (missingElement) {
+          missingElement.setAttribute('tabindex', '-1');
           missingElement.scrollIntoView(scrollIntoViewOptions);
+          missingElement.focus();
           resetLoadingObserver(observer, observerTimeout);
         }
       });


### PR DESCRIPTION
I'm using this component in a Gatsby project and it's working quite well but I face a major caveat when targeting an anchor on an other page than the current one: focus is moved **to the top of the page**. So even though the UI scrolls to the anchor on screen, users not relying on screen (such as keyboard users) are actually redirected to the top of the page instead of the targeted anchor in the page.
This might be related to Gatsby behavior. Yet, it's nice to explicitely [move focus to the targeted element](https://govtnz.github.io/web-a11y-guidance/ka/accessible-ux-best-practices/keyboard-a11y/keyboard-focus/focus-management.html#using-the-focus-method) anyway, so keyboard users are also redirected to the anchor instead of to the top of the page.